### PR TITLE
add production mysql2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,5 +68,8 @@ group :test do
   gem "webdrivers"
 end
 
+group :production do
+  gem "mysql2", "~> 0.5"
+end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
## 概要

- デプロイ時エラー対応
mysql2が見つからない旨のエラーであることから、gemfileにmysqlを追加し、`bundle install`した