### PR TITLE
deploy errorに伴うmanifest.jsの修正

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,2 @@
-//= link_tree ../images
+//= link_tree ../../../public/images
 //= link_directory ../../javascript/stylesheets .scss


### PR DESCRIPTION
## 概要

`Sprockets::ArgumentError: link_tree argument must be a directory`エラーが表示されたことから、manifest.jsを修正した。